### PR TITLE
Cli interpreter

### DIFF
--- a/arena/scene.py
+++ b/arena/scene.py
@@ -11,7 +11,6 @@ from .events import *
 from .objects import *
 from .utils import *
 
-
 class Scene(ArenaMQTT):
     """
     Gives access to an ARENA scene.
@@ -95,6 +94,11 @@ class Scene(ArenaMQTT):
             # create ARENA-py Objects from persist server
             # no need to return anything here
             self.get_persisted_objs()
+            
+            # check if we want to start the command interpreter
+            enable_interp = os.getenv("ENABLE_INTERPRETER", 'False').lower() in ('true', '1', 't')
+            if enable_interp: 
+                ArenaCmdInterpreter(self).start()
 
     async def process_message(self):
         while True:

--- a/arena/utils/__init__.py
+++ b/arena/utils/__init__.py
@@ -1,1 +1,2 @@
 from .utils import Utils
+from .cmd_interpreter import ArenaCmdInterpreter

--- a/arena/utils/cmd_interpreter.py
+++ b/arena/utils/cmd_interpreter.py
@@ -1,0 +1,79 @@
+# A simple command interpreter to inspect/manipulate arena programs from the cli
+import cmd, sys, json, threading, asyncio
+
+class ArenaCmdInterpreter(cmd.Cmd):
+    intro = 'Type help or ? to list available commands.\n'
+    prompt = '# '
+    file = None
+
+    __show_keywords =  ('scene', 'users', 'auth', 'all_objects', 'msg_io')
+    __get_keywords =  ('persisted_objs', 'persisted_scene_option', 'writable_scenes', 'user_list')
+
+    def __serialize_obj(self, obj):
+        if isinstance(obj, datetime):
+            return str(obj)
+        if hasattr(obj, '__dict__'):
+            return obj.__dict__
+        raise TypeError("Type not serializable")
+    
+    def __init__(self, scene):
+        super().__init__(completekey='tab')
+        self._scene = scene
+
+    def __cmd_loop_thread(self):
+        self.cmdloop()
+        
+    def start(self):
+        t = threading.Thread(name='interpreter_thread', target=self.__cmd_loop_thread)
+        t.start()
+    
+    def do_show(self, arg):
+        if arg not in self.__show_keywords:
+            self.help_show()
+            return            
+        try:
+            obj = getattr(self._scene, arg)
+        except AttributeError:
+            obj = {}            
+        print(json.dumps(obj, indent=4, sort_keys=True, default=self.__serialize_obj))
+
+    def help_show(self):
+        print(f"Display scene attributes: {[i for i in self.__show_keywords]}")
+
+    def do_get(self, arg):
+        if arg not in self.__get_keywords:
+            self.help_get()
+            return     
+        try:       
+            scene_get = getattr(self._scene, f"get_{arg}")
+        except AttributeError:
+            return
+        if callable(scene_get):
+            print(scene_get(self._scene))
+    
+    def help_get(self):
+        print(f"Scene get_* methods: {[i for i in self.__get_keywords]}. E.g:\n")
+        print("\tget persisted_objs => returns all persisted objects in the scene (by executing scene.get_persisted_objs)\n")
+        
+    def _task_exit(self, loop):
+        loop.stop()
+        
+    def do_exit(self, arg):
+        answer = ""
+        while answer not in ["y", "n"]:
+            answer = input("This will terminate the ARENA program. Are you sure [Y/N]? ").lower()
+        if answer == "y":
+            print("Exiting...")
+            tasks = [task for task in asyncio.all_tasks()]
+            list(map(lambda task: task.cancel(), tasks))
+                
+            sys.exit()
+
+    def do_quit(self, arg):
+        self.do_exit(arg)
+
+    def help_exit(self):
+        print("Exit program.")
+
+    def help_quit(self):
+        self.help_exit()

--- a/arena/utils/cmd_interpreter.py
+++ b/arena/utils/cmd_interpreter.py
@@ -1,6 +1,7 @@
-# A simple command interpreter to inspect/manipulate arena programs from the cli
-import cmd, sys, json, threading, asyncio
+# A simple command interpreter 
 
+import cmd, sys, json, threading, asyncio
+from datetime import date, datetime
 class ArenaCmdInterpreter(cmd.Cmd):
     intro = 'Type help or ? to list available commands.\n'
     prompt = '# '
@@ -10,7 +11,7 @@ class ArenaCmdInterpreter(cmd.Cmd):
     __get_keywords =  ('persisted_objs', 'persisted_scene_option', 'writable_scenes', 'user_list')
 
     def __serialize_obj(self, obj):
-        if isinstance(obj, datetime):
+        if isinstance(obj, (datetime, date)):
             return str(obj)
         if hasattr(obj, '__dict__'):
             return obj.__dict__
@@ -64,9 +65,6 @@ class ArenaCmdInterpreter(cmd.Cmd):
             answer = input("This will terminate the ARENA program. Are you sure [Y/N]? ").lower()
         if answer == "y":
             print("Exiting...")
-            tasks = [task for task in asyncio.all_tasks()]
-            list(map(lambda task: task.cancel(), tasks))
-                
             sys.exit()
 
     def do_quit(self, arg):


### PR DESCRIPTION
Added a simple interpreter to inspect/manipulate arena programs from the cli.

For now, behind an enable flag:
ENABLE_INTERPRETER=1 python3 box.py  

Example session:
```
Signing in to the ARENA...
Using cached Google authentication.
Authenticated Google account: nampereira@gmail.com
Fetching ARENA configuration...
Using remote-authenticated MQTT token.
ARENA Token Username: npereira
ARENA Token valid for: 23:59:59.120886h
=====
Loading: https://arenaxr.org/npereira/example, realm=realm
Connecting to the ARENA... Connected!
=====
Type help or ? to list available commands.

# help

Documented commands (type help <topic>):
========================================
exit  get  help  quit  show

# show scene
"example"
```