### PR TITLE
Animation followup

### DIFF
--- a/arena/attributes/animation.py
+++ b/arena/attributes/animation.py
@@ -1,6 +1,8 @@
 from ..utils import Utils
 from .attribute import Attribute
 from .position import Position
+from .rotation import Rotation
+from .scale import Scale
 
 class Animation(Attribute):
     """
@@ -11,13 +13,11 @@ class Animation(Attribute):
         if "start" in kwargs:
             if isinstance(kwargs["start"], tuple) or isinstance(kwargs["start"], list):
                 kwargs["start"] = Utils.tuple_to_string(kwargs["start"])
-            # can get away with using Position.to_str() even if animation is rotation (euler) or scale
-            # since we just want the 3 values to be a space separated string
-            elif isinstance(kwargs["start"], Position):
-                kwargs["start"] = kwargs["start"].to_str()
+            elif isinstance(kwargs["start"], (Position, Rotation, Scale)):
+                kwargs["start"] = vars(kwargs["start"])
         if "end" in kwargs:
             if isinstance(kwargs["end"], tuple) or isinstance(kwargs["end"], list):
                 kwargs["end"] = Utils.tuple_to_string(kwargs["end"])
-            elif isinstance(kwargs["end"], Position):
-                kwargs["end"] = kwargs["end"].to_str()
+            elif isinstance(kwargs["end"], (Position, Rotation, Scale)):
+                kwargs["end"] = vars(kwargs["end"])
         super().__init__(**kwargs)

--- a/arena/objects/arena_object.py
+++ b/arena/objects/arena_object.py
@@ -186,6 +186,8 @@ class Object(BaseObject):
             else:
                 json_data[k] = v
 
+        json_payload.pop("delayed_prop_tasks", None)
+
         json_payload["data"] = json_data
         self.json_postprocess(json_payload, json_data)
         return self.json_encode(json_payload)

--- a/arena/objects/arena_object.py
+++ b/arena/objects/arena_object.py
@@ -76,6 +76,8 @@ class Object(BaseObject):
         # add current object to all_objects dict
         Object.add(self)
 
+        self.delayed_prop_tasks = {}  # dict of delayed property tasks
+
     def update_attributes(self, evt_handler=None, update_handler=None, **kwargs):
         if evt_handler:
             self.evt_handler = evt_handler
@@ -118,8 +120,8 @@ class Object(BaseObject):
 
     def json_preprocess(self, **kwargs):
         # kwargs are for additional param to add to json, like "action":"create"
-        json_payload = { k:v for k,v in vars(self).items() if k != "evt_handler" and \
-                                            k != "update_handler" and k != "animations" }
+        json_payload = {k: v for k, v in vars(self).items() if k != "evt_handler" and \
+                        k != "update_handler" and k != "animations" and k != "delayed_prop_tasks"}
         json_payload.update(kwargs)
         return json_payload
 
@@ -202,6 +204,8 @@ class Object(BaseObject):
     def remove(cls, obj):
         object_id = obj.object_id
         del Object.all_objects[object_id]
+        for task in obj.delayed_prop_tasks.values():  # Cancel all pending tasks
+            task.cancel()
 
     @classmethod
     def exists(cls, object_id):

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -278,11 +278,17 @@ class Scene(ArenaMQTT):
         if kwargs:
             obj.update_attributes(**kwargs)
 
-        # Check if any keys in kwargs are in delayed_prop_tasks, cancel the
-        # corresponding tasks if so. Maybe faster to iterate on delayed_prop_tasks
-        # but then we mutate the dict while iterating...
+        # Check if any keys in delayed_prop_tasks are pending new animations
+        # and cancel corresponding final update tasks or, if they are in
+        # kwarg property updates, cancel the task as well as the animation
         need_to_run_animations = False
         if len(obj.delayed_prop_tasks) > 0:
+            for anim in obj.animations:
+                if anim.property in obj.delayed_prop_tasks:
+                    task_to_cancel = obj.delayed_prop_tasks[anim.property]
+                    task_to_cancel.cancel()
+                    del task_to_cancel
+
             for k in kwargs:
                 if str(k) in obj.delayed_prop_tasks:
                     need_to_run_animations = True

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -343,11 +343,10 @@ class Scene(ArenaMQTT):
         :param anim: Animation to run
         :return: created async task
         """
-        duration = anim.duration
-
         async def delayed_task():
-            await asyncio.sleep(duration)
-            self.update_object(obj, **{anim.property: anim.end})
+            await asyncio.sleep(anim.dur / 1000) # convert ms to s
+            final_state = anim.start if (getattr(anim, 'dir', 'normal') == 'reverse') else anim.end
+            self.update_object(obj, **{anim.property: final_state})
 
         return asyncio.create_task(delayed_task())
 

--- a/examples/attributes/animation.py
+++ b/examples/attributes/animation.py
@@ -5,7 +5,7 @@ scene = Scene(host="arenaxr.org", scene="example", debug=True)
 my_torus1 = Torus(
     object_id="my_torus1",
     position=(0, 2, 0),
-    radius=1,
+    radius=0.75,
     persist=True,
 )
 
@@ -20,11 +20,11 @@ my_torus2 = Torus(
 @scene.run_once
 def move_torus1():
     my_torus1.dispatch_animation(
-        Animation(property="Position", start=(0, 2, 0), end=(-5, 2, -5),
+        Animation(property="position", start=Position(0, 2, 0), end=Position(-5, 2, -5),
                   easing="linear", dur=8000)
     )
     my_torus1.dispatch_animation(
-        Animation(property="Rotation", start=(0, 0, 0), end=(0, 360, 0),
+        Animation(property="rotation", start=Rotation(0, 0, 0), end=Rotation(0, 360, 0),
                   easing="linear", dur=2000, loop=True)
     )
     scene.update_object(my_torus1)
@@ -33,17 +33,23 @@ def move_torus1():
 @scene.run_once
 def move_torus2():
     my_torus2.dispatch_animation(
-        Animation(property="Position", start=(0, 4, 0), end=(-5, 4, -5),
+        Animation(property="position", start=Position(0, 4, 0), end=Position(-5, 4, -5),
                   easing="easeInQuad", dur=4000)
     )
     scene.update_object(my_torus2)
 
 
 def cancel_torus1_move():
-    scene.update_object(my_torus1, Position=(-6, 2, -6))  # Move to new spot
+    scene.update_object(my_torus1, position=Position(-8, 2, -5))  # Move to new spot
+
+
+def change_torus2_color():
+    scene.update_object(my_torus2, color=Color(255, 0, 0))  # Change color to red
 
 
 scene.add_object(my_torus1)
 scene.add_object(my_torus2)
+print("Moving both shapes in same direction")
 scene.run_after_interval(cancel_torus1_move, 5000)
+scene.run_after_interval(change_torus2_color, 2000)
 scene.run_tasks()

--- a/examples/attributes/animation.py
+++ b/examples/attributes/animation.py
@@ -16,6 +16,13 @@ my_torus2 = Torus(
     persist=True,
 )
 
+my_torus3 = Torus(
+    object_id="my_torus3",
+    position=(0, 6, 0),
+    radius=0.25,
+    persist=True,
+)
+
 
 @scene.run_once
 def move_torus1():
@@ -39,17 +46,41 @@ def move_torus2():
     scene.update_object(my_torus2)
 
 
+@scene.run_once
+def move_torus3():
+    my_torus3.dispatch_animation(
+        Animation(property="position", start=Position(0, 6, 0), end=Position(-5, 6, -5),
+                  easing="linear", dur=6000)
+    )
+    scene.update_object(my_torus3)
+
+
 def cancel_torus1_move():
+    print("Cancelling animation and jumping torus1 to new location")
     scene.update_object(my_torus1, position=Position(-8, 2, -5))  # Move to new spot
 
 
 def change_torus2_color():
+    print("Changing torus2 color (should not affect animation")
     scene.update_object(my_torus2, color=Color(255, 0, 0))  # Change color to red
+
+
+def change_torus3_animation():
+    print("Overriding torus3 animation and cancelling original task. Note that the "
+          "position update will not be in correct position because we are not yet "
+          "also performing interp on position changes in arena-py")
+    my_torus3.dispatch_animation(
+        Animation(property="position", start=Position(-2.5, 6, -2.5),
+                  end=Position(0, 6, 0), easing="linear", dur=1500)
+    )
+    scene.update_object(my_torus3)
 
 
 scene.add_object(my_torus1)
 scene.add_object(my_torus2)
-print("Moving both shapes in same direction")
+scene.add_object(my_torus3)
 scene.run_after_interval(cancel_torus1_move, 5000)
 scene.run_after_interval(change_torus2_color, 2000)
+scene.run_after_interval(change_torus3_animation, 3000)
+print("Moving all shapes in same direction")
 scene.run_tasks()

--- a/examples/attributes/animation.py
+++ b/examples/attributes/animation.py
@@ -23,7 +23,12 @@ def move_torus1():
         Animation(property="Position", start=(0, 2, 0), end=(-5, 2, -5),
                   easing="linear", dur=8000)
     )
+    my_torus1.dispatch_animation(
+        Animation(property="Rotation", start=(0, 0, 0), end=(0, 360, 0),
+                  easing="linear", dur=2000, loop=True)
+    )
     scene.update_object(my_torus1)
+
 
 @scene.run_once
 def move_torus2():
@@ -34,6 +39,11 @@ def move_torus2():
     scene.update_object(my_torus2)
 
 
+def cancel_torus1_move():
+    scene.update_object(my_torus1, Position=(-6, 2, -6))  # Move to new spot
+
+
 scene.add_object(my_torus1)
 scene.add_object(my_torus2)
+scene.run_after_interval(cancel_torus1_move, 5000)
 scene.run_tasks()

--- a/examples/attributes/animation.py
+++ b/examples/attributes/animation.py
@@ -1,18 +1,39 @@
 from arena import *
 
-scene = Scene(host="arenaxr.org", scene="example")
+scene = Scene(host="arenaxr.org", scene="example", debug=True)
 
-my_torus = Torus(
-    object_id="my_torus",
-    position=(0,2,-5),
-    scale=(1.0,1.0,1.0),
+my_torus1 = Torus(
+    object_id="my_torus1",
+    position=(0, 2, 0),
+    radius=1,
+    persist=True,
 )
 
-@scene.run_once
-def rotate_torus():
-    my_torus.dispatch_animation(
-            Animation(property="rotation",start=(0,0,0),end=(0,360,0),easing="linear",dur=1000)
-        )
-    scene.update_object(my_torus)
+my_torus2 = Torus(
+    object_id="my_torus2",
+    position=(0, 4, 0),
+    radius=0.5,
+    persist=True,
+)
 
+
+@scene.run_once
+def move_torus1():
+    my_torus1.dispatch_animation(
+        Animation(property="Position", start=(0, 2, 0), end=(-5, 2, -5),
+                  easing="linear", dur=8000)
+    )
+    scene.update_object(my_torus1)
+
+@scene.run_once
+def move_torus2():
+    my_torus2.dispatch_animation(
+        Animation(property="Position", start=(0, 4, 0), end=(-5, 4, -5),
+                  easing="easeInQuad", dur=4000)
+    )
+    scene.update_object(my_torus2)
+
+
+scene.add_object(my_torus1)
+scene.add_object(my_torus2)
 scene.run_tasks()


### PR DESCRIPTION
This follows up the currently client-side only property animation/tweens (not to be confused with gltf morph or keyframe animations) with a separate property update after the expected duration.

This also attempts to handle interruptions of the animation which should cancel the initial timed property update.