### PR TITLE
Add private message support

### DIFF
--- a/arena/objects/arena_object.py
+++ b/arena/objects/arena_object.py
@@ -35,9 +35,6 @@ class Object(BaseObject):
         private = kwargs.get("private", False)
         if "private" in kwargs: del kwargs["private"]
 
-        program_id = kwargs.get("program_id", None)
-        if "program_id" in kwargs: del kwargs["program_id"]
-
         private_userid = kwargs.get("private_userid", None)
         if "private_userid" in kwargs: del kwargs["private_userid"]
 
@@ -81,14 +78,14 @@ class Object(BaseObject):
         if ttl:
             self.ttl = ttl
 
+        # This is with regard to its interaction
         if private:
+            # Note: public objects *can* have private clicks, mouseover, etc.
             self.private = private
-
-        if program_id:
-            self.program_id = program_id
 
         if private_userid:
             self._private_userid = private_userid  # None is public
+            self.private = True # private objects are always private interaction
 
         self.evt_handler = evt_handler
         self.update_handler = update_handler
@@ -119,9 +116,6 @@ class Object(BaseObject):
 
         if "private" in self:
             self.private = kwargs.get("private", self.private)
-
-        if "program_id" in self:
-            self.program_id = kwargs.get("program_id", self.program_id)
 
         if "private_userid" in self:
             self._private_userid = kwargs.get("private_userid", self._private_userid)

--- a/arena/objects/arena_object.py
+++ b/arena/objects/arena_object.py
@@ -13,6 +13,7 @@ class Object(BaseObject):
     type = "object"
     object_type = "entity"
     all_objects = {} # dict of all objects created so far
+    private_objects = {} # dict of all private objects created so far
 
     def __init__(self, evt_handler=None, update_handler=None, **kwargs):
         # "object_id" is required in kwargs, defaulted to random uuid4
@@ -95,6 +96,9 @@ class Object(BaseObject):
 
         # add current object to all_objects dict
         Object.add(self)
+        # If private, add to private_objects dict
+        if private_userid:
+            Object.add_private(self)
 
         self.delayed_prop_tasks = {}  # dict of delayed property tasks
 
@@ -220,6 +224,15 @@ class Object(BaseObject):
     def add(cls, obj):
         object_id = obj.object_id
         Object.all_objects[object_id] = obj
+
+    @classmethod
+    def add_private(cls, obj):
+        private_userid = getattr(obj, "_private_userid", None)
+        if private_userid is None:
+            raise ValueError("No private user id specified")
+        if private_userid not in Object.private_objects:
+            raise ValueError(f"User {private_userid} does not exist")
+        Object.private_objects[private_userid][obj.object_id] = obj
 
     @classmethod
     def remove(cls, obj):

--- a/arena/objects/arena_object.py
+++ b/arena/objects/arena_object.py
@@ -31,6 +31,15 @@ class Object(BaseObject):
         ttl = kwargs.get("ttl", None)
         if "ttl" in kwargs: del kwargs["ttl"]
 
+        private = kwargs.get("private", False)
+        if "private" in kwargs: del kwargs["private"]
+
+        program_id = kwargs.get("program_id", None)
+        if "program_id" in kwargs: del kwargs["program_id"]
+
+        private_userid = kwargs.get("private_userid", None)
+        if "private_userid" in kwargs: del kwargs["private_userid"]
+
         # remove timestamp, if exists
         if "timestamp" in kwargs: del kwargs["timestamp"]
 
@@ -71,6 +80,15 @@ class Object(BaseObject):
         if ttl:
             self.ttl = ttl
 
+        if private:
+            self.private = private
+
+        if program_id:
+            self.program_id = program_id
+
+        if private_userid:
+            self._private_userid = private_userid  # None is public
+
         self.evt_handler = evt_handler
         self.update_handler = update_handler
         self.animations = []
@@ -94,6 +112,15 @@ class Object(BaseObject):
         self.persist = kwargs.get("persist", self.persist)
         if "ttl" in self:
             self.ttl = kwargs.get("ttl", self.ttl)
+
+        if "private" in self:
+            self.private = kwargs.get("private", self.private)
+
+        if "program_id" in self:
+            self.program_id = kwargs.get("program_id", self.program_id)
+
+        if "private_userid" in self:
+            self._private_userid = kwargs.get("private_userid", self._private_userid)
 
         data = self.data
         Data.update_data(data, kwargs)
@@ -122,7 +149,7 @@ class Object(BaseObject):
 
     def json_preprocess(self, **kwargs):
         # kwargs are for additional param to add to json, like "action":"create"
-        skipped_keys = ["evt_handler", "update_handler", "animations", "delayed_prop_tasks"]
+        skipped_keys = ["evt_handler", "update_handler", "animations", "delayed_prop_tasks", "_private_userid"]
         json_payload = {k: v for k, v in vars(self).items() if k not in skipped_keys}
         json_payload.update(kwargs)
         return json_payload

--- a/arena/objects/arena_object.py
+++ b/arena/objects/arena_object.py
@@ -109,16 +109,22 @@ class Object(BaseObject):
         if "data" not in self:
             return
 
-        # update "persist", and "ttl"
-        self.persist = kwargs.get("persist", self.persist)
-        if "ttl" in self:
-            self.ttl = kwargs.get("ttl", self.ttl)
+        if "persist" in kwargs:
+            del kwargs["persist"]
+            self.persist = kwargs.get("private")
 
-        if "private" in self:
-            self.private = kwargs.get("private", self.private)
+        if "ttl" in kwargs:
+            del kwargs["ttl"]
+            self.ttl = kwargs.get("ttl")
 
-        if "private_userid" in self:
-            self._private_userid = kwargs.get("private_userid", self._private_userid)
+        if "private" in kwargs:
+            del kwargs["private"]
+            self.private = kwargs.get("private")
+
+        if "private_userid" in kwargs:
+            del kwargs["private_userid"]
+            self._private_userid = kwargs.get("private_userid")
+            self.private = True
 
         data = self.data
         Data.update_data(data, kwargs)

--- a/arena/scene.py
+++ b/arena/scene.py
@@ -480,6 +480,9 @@ class Scene(ArenaMQTT):
         """Public function to create an object"""
         if not isinstance(obj, Object):
             raise ValueError(f"Not a valid ARENA object to add to scene: {type(obj)}")
+        # We have to set program_id here, as only scene has access to its userid
+        if getattr(obj, "private", True):
+            obj.program_id = self.userid
         res = self._publish(obj, "create")
         self.run_animations(obj)
         return res
@@ -494,6 +497,10 @@ class Scene(ArenaMQTT):
         """Public function to update an object"""
         if kwargs:
             obj.update_attributes(**kwargs)
+
+        # We have to update program_id here, as only scene has access to its userid
+        if getattr(obj, "private", True):
+            obj.program_id = self.userid
 
         # Check if any keys in delayed_prop_tasks are pending new animations
         # and cancel corresponding final update tasks or, if they are in

--- a/examples/simple/private-objs.py
+++ b/examples/simple/private-objs.py
@@ -6,22 +6,37 @@ def user_leave_callback(scene, cam, msg):
     print("left:", cam.object_id)
     print("Private Objects:", scene.get_private_objects())
 
+def report_click(scene, evt, msg):
+    if evt.type == "mousedown":
+        print(f"User {evt.object_id} clicked on {evt.data.target}")
+
 def user_join_callback(scene, cam, msg):
     username = cam.object_id
     print("joined:", username)
+    random_y = 0.5 + random.randrange(3)
+    random_z = -1 - random.randrange(5)
     user_text = Text(
         object_id=f"text_{username}",
         value=f"Hello {username}!",
         align="center",
         font="mozillavr",
         # https://aframe.io/docs/1.4.0/components/text.html#stock-fonts
-        position=(0, 0.5 + random.randrange(3), -1 -random.randrange(5)),
+        position=(0, random_y, random_z),
         scale=(1.5, 1.5, 1.5),
         color=(100, 255, 255),
-        private=True,
-        private_userid=username
+        private_userid=username,
+    )
+    user_box = Box(
+        object_id=f"box_{username}",
+        position=(0, 0.75 + random_y, random_z),
+        scale=(0.5, 0.5, 0.5),
+        color=(100, 255, 255),
+        private_userid=username,
+        clickable=True,
+        evt_handler=report_click,
     )
     scene.add_object(user_text)
+    scene.add_object(user_box)
     print("Private Objects:", scene.get_private_objects())
 
 scene = Scene(host="arenaxr.org", scene="example")

--- a/examples/simple/private-objs.py
+++ b/examples/simple/private-objs.py
@@ -1,0 +1,31 @@
+from arena import *
+import random
+
+
+def user_leave_callback(scene, cam, msg):
+    print("left:", cam.object_id)
+    print("Private Objects:", scene.get_private_objects())
+
+def user_join_callback(scene, cam, msg):
+    username = cam.object_id
+    print("joined:", username)
+    user_text = Text(
+        object_id=f"text_{username}",
+        value=f"Hello {username}!",
+        align="center",
+        font="mozillavr",
+        # https://aframe.io/docs/1.4.0/components/text.html#stock-fonts
+        position=(0, 0.5 + random.randrange(3), -1 -random.randrange(5)),
+        scale=(1.5, 1.5, 1.5),
+        color=(100, 255, 255),
+        private=True,
+        private_userid=username
+    )
+    scene.add_object(user_text)
+    print("Private Objects:", scene.get_private_objects())
+
+scene = Scene(host="arenaxr.org", scene="example")
+scene.user_join_callback = user_join_callback
+scene.user_left_callback = user_leave_callback
+
+scene.run_tasks()

--- a/examples/simple/private-objs.py
+++ b/examples/simple/private-objs.py
@@ -15,6 +15,7 @@ def user_join_callback(scene, cam, msg):
     print("joined:", username)
     random_y = 0.5 + random.randrange(3)
     random_z = -1 - random.randrange(5)
+    # Text that only user can see
     user_text = Text(
         object_id=f"text_{username}",
         value=f"Hello {username}!",
@@ -26,6 +27,7 @@ def user_join_callback(scene, cam, msg):
         color=(100, 255, 255),
         private_userid=username,
     )
+    # Clickable box that only user can see
     user_box = Box(
         object_id=f"box_{username}",
         position=(0, 0.75 + random_y, random_z),
@@ -35,8 +37,14 @@ def user_join_callback(scene, cam, msg):
         clickable=True,
         evt_handler=report_click,
     )
-    scene.add_object(user_text)
-    scene.add_object(user_box)
+    # Red box that everyone can see
+    user_public_box = Box(
+        object_id=f"box_{username}_public",
+        position=(0, 1.25 + random_y, random_z),
+        scale=(0.5, 0.5, 0.5),
+        color=(255, 0, 0),
+    )
+    scene.add_objects([user_text, user_box, user_public_box])
     print("Private Objects:", scene.get_private_objects())
 
 scene = Scene(host="arenaxr.org", scene="example")


### PR DESCRIPTION
TODO: Add documentation

New kwargs for objects: `private` and `private_userid`.

Note that `private_userid` implies `private`

The top-level mqtt msg attribute `program_id` is automatically filled in for `private` messages

Covers one of primary features what was added in topic-v5, ability to send an object create/update specifically to one user.